### PR TITLE
fix(ScheduledFeeding): change fetch URL

### DIFF
--- a/components/feeding/ScheduledFeeding.tsx
+++ b/components/feeding/ScheduledFeeding.tsx
@@ -170,7 +170,7 @@ export default function ScheduledFeeding() {
     const updatedSchedules = [...userSchedules]
     updatedSchedules.splice(index, 1)
 
-    fetch(`http://localhost:5050/api/schedules/user/${user.email}`, {
+    fetch(`/api/schedules/user/${user.email}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ schedule: updatedSchedules }),


### PR DESCRIPTION
# Summary

Change fetch URL to use `/api/schedules/user/` instead of `localhost:5050/api/schedules/user`