### PR TITLE
fix: whitelist video feed URL in next.config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,12 +3,15 @@ const nextConfig = {
   async rewrites() {
     return process.env.NODE_ENV === 'development'
       ? [
-        {
-          source: '/api/:path*',
-          destination: 'http://localhost:5050/api/:path*',
-        },
-      ]
+          {
+            source: '/api/:path*',
+            destination: 'http://localhost:5050/api/:path*',
+          },
+        ]
       : []
+  },
+  images: {
+    domains: ['spf.sebastian.sh'],
   },
 }
 


### PR DESCRIPTION
## Summary

- Whitelist the video feed URL so that it shows up on the call page