### PR TITLE
fix: use remotePatterns instead of domains

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,12 @@ const nextConfig = {
       : []
   },
   images: {
-    domains: ['spf.sebastian.sh'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'spf.sebastian.sh',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary 

- image.domains is deprecated, use image.remotePatterns